### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Deep Neural Networks.
 
 ### 2022
 
+- [[ECCV](https://www.ecva.net/papers/eccv_2022/papers_ECCV/papers/136710416.pdf)] Weight Fixing Networks.  [__`qnn`__] [[code]](https://github.com/subiawaud/Weight_Fix_Networks)
 - [[IJCV](https://arxiv.org/abs/2109.12338)] Distribution-sensitive Information Retention for Accurate Binary Neural Network.  [__`bnn`__]
 - [[ICML](https://proceedings.mlr.press/v162/huang22h.html)] SDQ: Stochastic Differentiable Quantization with Mixed Precision [**`qnn`**]
 - [[ICML](https://proceedings.mlr.press/v162/dong22a.html)] Finding the Task-Optimal Low-Bit Sub-Distribution in Deep Neural Networks [**`qnn`**] [**`hardware`**]


### PR DESCRIPTION
Hi,

I've added in Weight Fixing Networks - a quantization paper from ECCV in November 2022. 

Thanks!

Chris 